### PR TITLE
added two nodes for convenient change of topic for first and second input

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ What I came up with are the following nodes.
 * BooleanLogic: Can perform AND, OR and XOR operations on ```msg.payload``` on any number of topics.
 * Invert: Inverts the ```msg.payload```, e.g. true -> false.
 * Debug: A debug node that displays the status direcly in the editor, making it easier to see the boolean value at a specific point.
+* Two nodes ```Input A``` and ```Input B``` just for convenience to change the topic to A or B, respectively.
 
 All nodes attempts to convert the incoming ```msg.payload``` to a boolean value according to these rules:
 * Boolean values are taken as-is.

--- a/boolean-logic/BInputA.html
+++ b/boolean-logic/BInputA.html
@@ -1,0 +1,31 @@
+<!-- 
+Licensed under the MIT license, see LICENSE file.
+Author: Danny Drieß
+-->
+<script type="text/javascript">
+    RED.nodes.registerType('BInputA',{
+        category: 'boolean logic',
+        color: '#C0DEED',
+        defaults: {
+            name: {value:"A"}
+        },
+        inputs:1,
+        outputs:1,
+        icon: "serial.png",
+        label: function() {
+            return this.name||"A";
+        },
+        paletteLabel: function() { return "Input A"; }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="BInputA">
+    <div class="form-row">
+        <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="BInputA">
+    <p>Changes the topic to A such that it corresponds to a first input to the boolean logic node</p>
+</script>

--- a/boolean-logic/BInputA.js
+++ b/boolean-logic/BInputA.js
@@ -1,0 +1,13 @@
+// Licensed under the MIT license, see LICENSE file.
+// Author: Danny Drieß
+module.exports = function(RED) {
+    function inputA(config) {
+        RED.nodes.createNode(this,config);
+        var node = this;
+        this.on('input', function(msg) {
+            msg.topic = "A";
+            node.send(msg);
+        });
+    }
+    RED.nodes.registerType("BInputA",inputA);
+}

--- a/boolean-logic/BInputB.html
+++ b/boolean-logic/BInputB.html
@@ -1,0 +1,31 @@
+<!-- 
+Licensed under the MIT license, see LICENSE file.
+Author: Danny Drieß
+-->
+<script type="text/javascript">
+    RED.nodes.registerType('BInputB',{
+        category: 'boolean logic',
+        color: '#C0DEED',
+        defaults: {
+            name: {value:"B"}
+        },
+        inputs:1,
+        outputs:1,
+        icon: "serial.png",
+        label: function() {
+            return this.name||"B";
+        },
+        paletteLabel: function() { return "Input B"; }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="BInputB">
+    <div class="form-row">
+        <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="BInputB">
+    <p>Changes the topic to B such that it corresponds to a second input to the boolean logic node</p>
+</script>

--- a/boolean-logic/BInputB.js
+++ b/boolean-logic/BInputB.js
@@ -1,0 +1,13 @@
+// Licensed under the MIT license, see LICENSE file.
+// Author: Danny Drieß
+module.exports = function(RED) {
+    function inputB(config) {
+        RED.nodes.createNode(this,config);
+        var node = this;
+        this.on('input', function(msg) {
+            msg.topic = "B";
+            node.send(msg);
+        });
+    }
+    RED.nodes.registerType("BInputB",inputB);
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
         "nodes": {
 			"BooleanLogic": "boolean-logic/BooleanLogic.js",
 			"Invert": "boolean-logic/Invert.js",
-            "BDebug": "boolean-logic/BDebug.js"
+            "BDebug": "boolean-logic/BDebug.js",
+            "BInputA": "boolean-logic/BInputA.js",
+            "BInputB": "boolean-logic/BInputB.js"
         }
     }
 }


### PR DESCRIPTION
I often end up using your nodes in combination with lots of "change" or "function" nodes to alter the topics such that they can be understood as a first and second input. For convenience and cleaner flows, I created two extremely simple nodes that just change the topic to "A" and "B" directly without any configuration. 

These aren't really necessary, but I believe that it leads to more transparent flows that are faster to create.

Two things I don't like in my pull request:
- icons for the two new nodes
- size of the two new nodes: It would be cool to have them shorter, such that they are only the Letter "A" or "B" long. 